### PR TITLE
chore: bump POLARS_LATEST_KNOWN to 1.41

### DIFF
--- a/src/polypolarism/version_check.py
+++ b/src/polypolarism/version_check.py
@@ -76,7 +76,7 @@ def _leading_digits(s: str) -> int | None:
 # polars ships a new minor, bump ``POLARS_LATEST_KNOWN`` and
 # ``POLARS_FLOOR`` follows automatically (latest minor minus one). Anything
 # below ``POLARS_FLOOR`` triggers a PLW010 warning.
-POLARS_LATEST_KNOWN = Version(1, 40, 0)
+POLARS_LATEST_KNOWN = Version(1, 41, 0)
 POLARS_FLOOR = Version(POLARS_LATEST_KNOWN.major, POLARS_LATEST_KNOWN.minor - 1, 0)
 POLARS_SUPPORT_NOTE = (
     f"polypolarism supports polars >= {POLARS_FLOOR} (the latest two 1.x minor "

--- a/tests/test_version_check.py
+++ b/tests/test_version_check.py
@@ -359,10 +359,10 @@ dependencies = ["polars>=0.19.0"]
 #   - 1.25: Enum stabilized, below window.
 #   - 1.27: hist bin-closure shift, below window.
 #   - 1.32: selector-as-DSL change, below window.
-#   - 1.38: one minor below floor, below window.
-#   - 1.39: floor (==POLARS_LATEST_KNOWN.minor - 1), silent.
-#   - 1.40: latest known, silent.
-#   - 1.41: hypothetical future minor, silent (we don't reject the
+#   - 1.39: one minor below floor, below window.
+#   - 1.40: floor (==POLARS_LATEST_KNOWN.minor - 1), silent.
+#   - 1.41: latest known, silent.
+#   - 1.42: hypothetical future minor, silent (we don't reject the
 #     unknown-future direction; only "too old" is unsupported).
 @pytest.mark.parametrize(
     ("version_str", "should_warn"),
@@ -373,10 +373,10 @@ dependencies = ["polars>=0.19.0"]
         ("1.25.0", True),
         ("1.27.0", True),
         ("1.32.0", True),
-        ("1.38.0", True),
-        ("1.39.0", False),
+        ("1.39.0", True),
         ("1.40.0", False),
         ("1.41.0", False),
+        ("1.42.0", False),
     ],
 )
 class TestPolarsVersionLandmarks:


### PR DESCRIPTION
## Summary

- polars **1.41.2** was detected on PyPI as of 2026-06-01, one minor ahead of the previous `POLARS_LATEST_KNOWN = Version(1, 40, 0)`.
- `POLARS_LATEST_KNOWN` is bumped from `1.40` → `1.41` in `src/polypolarism/version_check.py`.
- `POLARS_FLOOR` is derived automatically as `latest_minor - 1`, so it advances from **1.39 → 1.40**.

## Impact on PLW010 warnings

| polars version | Before this bump | After this bump |
|---|---|---|
| < 1.39 | PLW010 | PLW010 |
| 1.39.x | silent | **PLW010** (now below floor) |
| 1.40.x | silent (floor) | silent (new floor) |
| 1.41.x | silent (latest) | silent (new latest) |

Projects that were pinned to `polars>=1.39` and running polypolarism will now see a PLW010 warning nudging them to upgrade. Projects on 1.40+ are unaffected.

## Test changes

The `TestPolarsVersionLandmarks` parametrize table in `tests/test_version_check.py` was updated to slide the window forward:
- `1.39.0` → `should_warn=True` (was `False`)
- `1.42.0` added as the new "hypothetical future minor" sentinel (`should_warn=False`)

All 596 tests pass; `ruff check` and `ruff format --check` are clean.

## Policy reference

See [ADR-0001](docs/adr/0001-polars-pandera-version-support.md) for the "latest two 1.x minor releases" support policy that governs this bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBhNsoR88KvQvstUJBTUyV)_