### PR TITLE
test(fixtures): pin adversarial-corpus boundary behaviors (7 rules, 11 fixtures)

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -118,8 +118,20 @@ Rules with both sides present (valid twin -> invalid twin):
 | null_count UInt32 mapping (issue #74) | `null_count_schema` | `null_count_wrong_dtype` |
 | to_dummies data-dependent schema (issue #74) | (annotation path shared with pivot) | `warning/to_dummies_unannotated` (PLW005, a warning, not an error) |
 
+| absent-tracking edge cases (#78) | `absent_rename_swap` (simultaneous swap), `absent_reintroduce_join` | `absent_rename_chain` (sequential renames accumulate), `absent_join_no_reintroduce` |
+| concat time-unit unification (#66) | `concat_time_unit_same` | `concat_time_unit_mixing` |
+| object-API `strict="filter"` mode (#88) | `object_api_strict_filter` (extras accepted at input) | `object_api_strict_filter_gone` (removed column is a PLY001 proof) |
+| `str.to_datetime` time_unit= / `%::z` (#66) | `str_to_datetime_time_unit` | `str_to_datetime_time_unit_wrong` |
+| bitwise NOT unsigned widths (#72) | `not_bitwise_unsigned_width` | `not_unsigned_declared_i64` |
+| bare-return laziness, eager direction (ADR-0006) | `adr0006_amendment_flows` (`matching_laziness`) | `bare_return_eager_into_lazy` |
+
 Intentionally unpaired:
 
+- `valid/backward_narrowing_scoped` — pins that backward-narrowed pins
+  do NOT leak across variables and are cleared by rebinding (the
+  false-positive guards for the ADR-0006 future-work feature). The
+  functions pin the *absence* of narrowing; there is no
+  wrong-declaration twin to write.
 - `valid/unknown_dtype_tracking` — pins the leniency design itself (Unknown
   columns stay registered). Its golden carries the `via:` notes that make
   the leniency visible; an invalid twin is impossible by construction.

--- a/tests/fixtures/invalid/absent_join_no_reintroduce.expected
+++ b/tests/fixtures/invalid/absent_join_no_reintroduce.expected
@@ -1,0 +1,2 @@
+join_does_not_reintroduce: FAIL
+  error: [PLY001] Column 'a' not found — it was removed earlier in this chain (drop/rename)

--- a/tests/fixtures/invalid/absent_join_no_reintroduce.py
+++ b/tests/fixtures/invalid/absent_join_no_reintroduce.py
@@ -24,5 +24,11 @@ class KeyedOnly(pa.DataFrameModel):
         coerce = True
 
 
-def join_does_not_reintroduce(df: pl.DataFrame, g: DataFrame[KeyedOnly]) -> pl.DataFrame:
+# The default is the runtime witness: a frame that really carries 'a'
+# and the join key, so the drop -> join -> select chain executes for real
+# in the differential harness (bare params are not synthesizable).
+_LEFT = pl.DataFrame({"k": [1, 2], "a": [10, 20]})
+
+
+def join_does_not_reintroduce(g: DataFrame[KeyedOnly], df: pl.DataFrame = _LEFT) -> pl.DataFrame:
     return df.drop("a").join(g, on="k").select(pl.col("a"))  # WRONG: 'a' is still absent

--- a/tests/fixtures/invalid/absent_join_no_reintroduce.py
+++ b/tests/fixtures/invalid/absent_join_no_reintroduce.py
@@ -1,0 +1,28 @@
+"""A join that does not carry the dropped name keeps it absent (issue #78).
+
+``drop("a")`` then a join whose other side provably lacks ``a`` cannot
+resurrect the name — the reference is still a guaranteed
+ColumnNotFoundError.
+
+False-positive twin: ``valid/absent_reintroduce_join`` (the other side
+pinning ``a`` does clear the mark).
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+
+
+class KeyedOnly(pa.DataFrameModel):
+    k: pl.Int64
+    z: str
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+def join_does_not_reintroduce(df: pl.DataFrame, g: DataFrame[KeyedOnly]) -> pl.DataFrame:
+    return df.drop("a").join(g, on="k").select(pl.col("a"))  # WRONG: 'a' is still absent

--- a/tests/fixtures/invalid/absent_rename_chain.expected
+++ b/tests/fixtures/invalid/absent_rename_chain.expected
@@ -1,0 +1,4 @@
+chained_rename_old_name: FAIL
+  error: [PLY001] Column 'a' not found — it was removed earlier in this chain (drop/rename)
+chained_rename_intermediate_name: FAIL
+  error: [PLY001] Column 'b' not found — it was removed earlier in this chain (drop/rename)

--- a/tests/fixtures/invalid/absent_rename_chain.py
+++ b/tests/fixtures/invalid/absent_rename_chain.py
@@ -1,0 +1,22 @@
+"""Sequential renames accumulate absence (issue #78 boundary).
+
+``rename({"a": "b"})`` then ``rename({"b": "c"})`` leaves only ``c``;
+both old names are provably gone and referencing either must fail.
+
+False-positive twin: ``valid/absent_rename_swap`` (a *simultaneous*
+swap keeps both names — the two must not be conflated).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def chained_rename_old_name(df: pl.DataFrame) -> pl.DataFrame:
+    renamed = df.rename({"a": "b"}).rename({"b": "c"})
+    return renamed.select(pl.col("a"))  # WRONG: 'a' was renamed away in step 1
+
+
+def chained_rename_intermediate_name(df: pl.DataFrame) -> pl.DataFrame:
+    renamed = df.rename({"a": "b"}).rename({"b": "c"})
+    return renamed.select(pl.col("b"))  # WRONG: 'b' was renamed away in step 2

--- a/tests/fixtures/invalid/bare_return_eager_into_lazy.expected
+++ b/tests/fixtures/invalid/bare_return_eager_into_lazy.expected
@@ -1,0 +1,2 @@
+eager_returned_as_bare_lazyframe: FAIL
+  error: [PLY032] Return type annotated bare pl.LazyFrame but inferred DataFrame[...]; .lazy() before returning.

--- a/tests/fixtures/invalid/bare_return_eager_into_lazy.py
+++ b/tests/fixtures/invalid/bare_return_eager_into_lazy.py
@@ -1,0 +1,16 @@
+"""A bare ``pl.LazyFrame`` return annotation rejects an eager frame.
+
+The missing direction of the bare-return laziness check
+(``invalid/adr0006_amendment_proofs`` pins lazy-returned-as-DataFrame).
+
+False-positive twin: ``valid/adr0006_amendment_flows``
+(``matching_laziness``).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def eager_returned_as_bare_lazyframe(lf: pl.LazyFrame) -> pl.LazyFrame:
+    return lf.collect()  # WRONG: collect() makes it eager; annotation says LazyFrame

--- a/tests/fixtures/invalid/concat_time_unit_mixing.expected
+++ b/tests/fixtures/invalid/concat_time_unit_mixing.expected
@@ -1,0 +1,3 @@
+concat_mixed_units: FAIL
+  error: [PLY020] concat: column 't' — Cannot unify types Datetime[us] and Datetime[ns]
+  error: [PLY040] Could not infer return type

--- a/tests/fixtures/invalid/concat_time_unit_mixing.py
+++ b/tests/fixtures/invalid/concat_time_unit_mixing.py
@@ -9,10 +9,11 @@ False-positive twin: ``valid/concat_time_unit_same``.
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import DataFrame
-from typing import Annotated
 
 
 class EventsUs(pa.DataFrameModel):

--- a/tests/fixtures/invalid/concat_time_unit_mixing.py
+++ b/tests/fixtures/invalid/concat_time_unit_mixing.py
@@ -1,0 +1,28 @@
+"""Vertical concat cannot unify mixed Datetime time units (issue #66 boundary).
+
+polars raises ``SchemaError: type Datetime('ns') is incompatible with
+expected type Datetime('us')`` — the time-unit analogue of
+``invalid/tz_mixing``.
+
+False-positive twin: ``valid/concat_time_unit_same``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+from typing import Annotated
+
+
+class EventsUs(pa.DataFrameModel):
+    t: Annotated[pl.Datetime, "us", None]
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+def concat_mixed_units(df: DataFrame[EventsUs]) -> DataFrame[EventsUs]:
+    ns_part = df.select(t=pl.col("t").cast(pl.Datetime("ns")))
+    return pl.concat([df.select(pl.col("t")), ns_part])  # WRONG: us vs ns cannot unify

--- a/tests/fixtures/invalid/not_unsigned_declared_i64.expected
+++ b/tests/fixtures/invalid/not_unsigned_declared_i64.expected
@@ -1,0 +1,2 @@
+invert_declared_i64: FAIL
+  error: [PLY040] Column 'x' has type UInt8, but declared type is Int64

--- a/tests/fixtures/invalid/not_unsigned_declared_i64.py
+++ b/tests/fixtures/invalid/not_unsigned_declared_i64.py
@@ -1,0 +1,29 @@
+"""``~UInt8`` declared Int64 is a dtype lie (issue #72 boundary).
+
+False-positive twin: ``valid/not_bitwise_unsigned_width``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+
+
+class Bytes(pa.DataFrameModel):
+    u: pl.UInt8
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+class WrongOut(pa.DataFrameModel):
+    x: pl.Int64  # WRONG: ~UInt8 stays UInt8
+
+    class Config:
+        strict = True
+
+
+def invert_declared_i64(df: DataFrame[Bytes]) -> DataFrame[WrongOut]:
+    return df.select(x=~pl.col("u"))

--- a/tests/fixtures/invalid/object_api_strict_filter_gone.expected
+++ b/tests/fixtures/invalid/object_api_strict_filter_gone.expected
@@ -1,0 +1,2 @@
+filtered_column_gone: FAIL
+  error: [PLY001] Column 'b' not found. Available columns: ['a']

--- a/tests/fixtures/invalid/object_api_strict_filter_gone.py
+++ b/tests/fixtures/invalid/object_api_strict_filter_gone.py
@@ -1,0 +1,32 @@
+"""``strict="filter"`` provably removes undeclared columns (issue #88).
+
+The validate output of a filter-mode schema is closed: a column the
+schema does not declare is gone on every execution, so referencing it
+is a provable missing-column error (PLY001-class, not the PLY042 lint —
+the output never "admits extras at runtime").
+
+False-positive twin: ``valid/object_api_strict_filter``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+
+
+class Src(pa.DataFrameModel):
+    a: int
+    b: str
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+filter_schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64)}, strict="filter")
+
+
+def filtered_column_gone(df: DataFrame[Src]) -> pl.DataFrame:
+    out = filter_schema.validate(df.select(pl.col("a"), pl.col("b")))
+    return out.select(pl.col("b"))  # WRONG: filter-validate removed 'b'

--- a/tests/fixtures/invalid/str_to_datetime_time_unit_wrong.expected
+++ b/tests/fixtures/invalid/str_to_datetime_time_unit_wrong.expected
@@ -1,0 +1,2 @@
+to_datetime_stale_unit: FAIL
+  error: [PLY040] Column 't' has type Datetime[ns], but declared type is Datetime[us]

--- a/tests/fixtures/invalid/str_to_datetime_time_unit_wrong.py
+++ b/tests/fixtures/invalid/str_to_datetime_time_unit_wrong.py
@@ -8,10 +8,11 @@ False-positive twin: ``valid/str_to_datetime_time_unit``.
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import DataFrame
-from typing import Annotated
 
 
 class Raw(pa.DataFrameModel):

--- a/tests/fixtures/invalid/str_to_datetime_time_unit_wrong.py
+++ b/tests/fixtures/invalid/str_to_datetime_time_unit_wrong.py
@@ -1,0 +1,33 @@
+"""Declaring the default unit for a ``time_unit="ns"`` parse is wrong (issue #66).
+
+The keyword changes the result to ``Datetime[ns]``; a stale ``us``
+declaration must fail.
+
+False-positive twin: ``valid/str_to_datetime_time_unit``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+from typing import Annotated
+
+
+class Raw(pa.DataFrameModel):
+    s: str
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+class ParsedWrong(pa.DataFrameModel):
+    t: Annotated[pl.Datetime, "us", None]  # WRONG: time_unit="ns" yields Datetime[ns]
+
+    class Config:
+        strict = True
+
+
+def to_datetime_stale_unit(df: DataFrame[Raw]) -> DataFrame[ParsedWrong]:
+    return df.select(t=pl.col("s").str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="ns"))

--- a/tests/fixtures/valid/absent_reintroduce_join.expected
+++ b/tests/fixtures/valid/absent_reintroduce_join.expected
@@ -1,0 +1,1 @@
+join_reintroduces_dropped: OK

--- a/tests/fixtures/valid/absent_reintroduce_join.py
+++ b/tests/fixtures/valid/absent_reintroduce_join.py
@@ -1,0 +1,28 @@
+"""A join's other side clears the absence mark (issue #78 amendment).
+
+``drop("a")`` records ``a`` as provably absent, but joining a frame
+whose schema pins ``a`` reintroduces the name — the amendment lists the
+join's other side as one of the three reintroduction paths
+(``with_columns``, a rename target, a join).
+
+False-negative twin: ``invalid/absent_join_no_reintroduce``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+
+
+class KeyedA(pa.DataFrameModel):
+    k: pl.Int64
+    a: pl.Int64
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+def join_reintroduces_dropped(df: pl.DataFrame, g: DataFrame[KeyedA]) -> pl.DataFrame:
+    return df.drop("a").join(g, on="k").select(pl.col("a"))

--- a/tests/fixtures/valid/absent_reintroduce_join.py
+++ b/tests/fixtures/valid/absent_reintroduce_join.py
@@ -24,5 +24,10 @@ class KeyedA(pa.DataFrameModel):
         coerce = True
 
 
-def join_reintroduces_dropped(df: pl.DataFrame, g: DataFrame[KeyedA]) -> pl.DataFrame:
+# Executable default for the differential harness (bare params are not
+# synthesizable): carries 'a' (to be dropped) and the join key.
+_LEFT = pl.DataFrame({"k": [1, 2], "a": [10, 20]})
+
+
+def join_reintroduces_dropped(g: DataFrame[KeyedA], df: pl.DataFrame = _LEFT) -> pl.DataFrame:
     return df.drop("a").join(g, on="k").select(pl.col("a"))

--- a/tests/fixtures/valid/absent_rename_swap.expected
+++ b/tests/fixtures/valid/absent_rename_swap.expected
@@ -1,0 +1,1 @@
+rename_swap_keeps_both: OK

--- a/tests/fixtures/valid/absent_rename_swap.py
+++ b/tests/fixtures/valid/absent_rename_swap.py
@@ -1,0 +1,17 @@
+"""Simultaneous rename swap keeps both names alive (issue #78 boundary).
+
+``rename({"a": "b", "b": "a"})`` is a swap — polars applies the mapping
+simultaneously, so both names still exist afterwards. A naive
+"old names become absent" implementation of ``FrameType.absent`` would
+mark both as provably removed and reject this valid code.
+
+False-negative twin: ``invalid/absent_rename_chain``.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def rename_swap_keeps_both(df: pl.DataFrame) -> pl.DataFrame:
+    return df.rename({"a": "b", "b": "a"}).select(pl.col("a"), pl.col("b"))

--- a/tests/fixtures/valid/backward_narrowing_scoped.expected
+++ b/tests/fixtures/valid/backward_narrowing_scoped.expected
@@ -1,0 +1,2 @@
+narrowing_does_not_cross_variables: OK
+narrowing_cleared_by_rebinding: OK

--- a/tests/fixtures/valid/backward_narrowing_scoped.py
+++ b/tests/fixtures/valid/backward_narrowing_scoped.py
@@ -1,0 +1,24 @@
+"""Backward narrowing stays scoped to its variable (ADR-0006 future-work).
+
+The pins a successful ``select`` writes back onto its source must not
+leak across variables, and rebinding the name discards them — otherwise
+assumption pins would manufacture false positives on unrelated frames.
+
+Intentionally unpaired: these functions pin the *absence* of narrowing
+(leniency must hold); there is no wrong-declaration twin to write.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+
+def narrowing_does_not_cross_variables(df: pl.DataFrame, df2: pl.DataFrame) -> pl.DataFrame:
+    _probe = df.select(pl.col("a").str.to_uppercase())
+    return df2.select(pl.col("a").dt.year())
+
+
+def narrowing_cleared_by_rebinding(df: pl.DataFrame, other: pl.DataFrame) -> pl.DataFrame:
+    _probe = df.select(pl.col("a").str.to_uppercase())
+    df = other
+    return df.select(pl.col("a").dt.year())

--- a/tests/fixtures/valid/concat_time_unit_same.expected
+++ b/tests/fixtures/valid/concat_time_unit_same.expected
@@ -1,0 +1,1 @@
+concat_same_unit: OK

--- a/tests/fixtures/valid/concat_time_unit_same.py
+++ b/tests/fixtures/valid/concat_time_unit_same.py
@@ -7,10 +7,11 @@ False-negative twin: ``invalid/concat_time_unit_mixing``.
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import DataFrame
-from typing import Annotated
 
 
 class EventsUs(pa.DataFrameModel):

--- a/tests/fixtures/valid/concat_time_unit_same.py
+++ b/tests/fixtures/valid/concat_time_unit_same.py
@@ -1,0 +1,25 @@
+"""Vertical concat with matching Datetime time units unifies cleanly.
+
+Same-unit frames concatenate; the result keeps the shared unit.
+
+False-negative twin: ``invalid/concat_time_unit_mixing``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+from typing import Annotated
+
+
+class EventsUs(pa.DataFrameModel):
+    t: Annotated[pl.Datetime, "us", None]
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+def concat_same_unit(a: DataFrame[EventsUs], b: DataFrame[EventsUs]) -> DataFrame[EventsUs]:
+    return pl.concat([a, b])

--- a/tests/fixtures/valid/not_bitwise_unsigned_width.expected
+++ b/tests/fixtures/valid/not_bitwise_unsigned_width.expected
@@ -1,0 +1,1 @@
+invert_preserves_uint8: OK

--- a/tests/fixtures/valid/not_bitwise_unsigned_width.py
+++ b/tests/fixtures/valid/not_bitwise_unsigned_width.py
@@ -1,0 +1,33 @@
+"""Bitwise NOT preserves unsigned widths (issue #72 boundary).
+
+``~UInt8`` stays UInt8 (two's-complement within the width: ``~1 == 254``)
+— the dtype-preserving rule must not collapse unsigned receivers to
+Int64.
+
+False-negative twin: ``invalid/not_unsigned_declared_i64``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+
+
+class Bytes(pa.DataFrameModel):
+    u: pl.UInt8
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+class BytesOut(pa.DataFrameModel):
+    x: pl.UInt8
+
+    class Config:
+        strict = True
+
+
+def invert_preserves_uint8(df: DataFrame[Bytes]) -> DataFrame[BytesOut]:
+    return df.select(x=~pl.col("u"))

--- a/tests/fixtures/valid/object_api_strict_filter.expected
+++ b/tests/fixtures/valid/object_api_strict_filter.expected
@@ -1,0 +1,1 @@
+filter_accepts_extras: OK

--- a/tests/fixtures/valid/object_api_strict_filter.py
+++ b/tests/fixtures/valid/object_api_strict_filter.py
@@ -1,0 +1,31 @@
+"""``strict="filter"`` schemas accept extra input columns (issue #88 boundary).
+
+pandera's third strict mode: ``validate`` *removes* undeclared columns
+instead of rejecting them, so feeding a wider frame is runtime-valid and
+the result is exactly the declared columns.
+
+False-negative twin: ``invalid/object_api_strict_filter_gone``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+
+
+class Src(pa.DataFrameModel):
+    a: int
+    b: str
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+filter_schema = pa.DataFrameSchema({"a": pa.Column(pl.Int64)}, strict="filter")
+
+
+def filter_accepts_extras(df: DataFrame[Src]) -> pl.DataFrame:
+    out = filter_schema.validate(df.select(pl.col("a"), pl.col("b")))
+    return out.select(pl.col("a"))

--- a/tests/fixtures/valid/str_to_datetime_time_unit.expected
+++ b/tests/fixtures/valid/str_to_datetime_time_unit.expected
@@ -1,0 +1,1 @@
+to_datetime_units: OK

--- a/tests/fixtures/valid/str_to_datetime_time_unit.py
+++ b/tests/fixtures/valid/str_to_datetime_time_unit.py
@@ -1,0 +1,39 @@
+"""``str.to_datetime`` follows its ``time_unit=`` argument and chrono offsets.
+
+The ``time_unit="ns"`` keyword changes the result unit (issue #66
+boundary), and the extended chrono offset directives (``%::z``) resolve
+``Datetime[UTC]`` like ``%z``.
+
+False-negative twin: ``invalid/str_to_datetime_time_unit_wrong``.
+"""
+
+from __future__ import annotations
+
+import pandera.polars as pa
+import polars as pl
+from pandera.typing.polars import DataFrame
+from typing import Annotated
+
+
+class Raw(pa.DataFrameModel):
+    s: str
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+class Parsed(pa.DataFrameModel):
+    ns_naive: Annotated[pl.Datetime, "ns", None]
+    us_utc: Annotated[pl.Datetime, "us", "UTC"]
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+def to_datetime_units(df: DataFrame[Raw]) -> DataFrame[Parsed]:
+    return df.select(
+        ns_naive=pl.col("s").str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="ns"),
+        us_utc=pl.col("s").str.to_datetime("%Y-%m-%d %H:%M:%S %::z"),
+    )

--- a/tests/fixtures/valid/str_to_datetime_time_unit.py
+++ b/tests/fixtures/valid/str_to_datetime_time_unit.py
@@ -9,14 +9,16 @@ False-negative twin: ``invalid/str_to_datetime_time_unit_wrong``.
 
 from __future__ import annotations
 
+from typing import Annotated
+
 import pandera.polars as pa
 import polars as pl
 from pandera.typing.polars import DataFrame
-from typing import Annotated
 
 
 class Raw(pa.DataFrameModel):
     s: str
+    s_off: str  # offset-bearing strings for the %::z parse
 
     class Config:
         strict = True
@@ -33,7 +35,10 @@ class Parsed(pa.DataFrameModel):
 
 
 def to_datetime_units(df: DataFrame[Raw]) -> DataFrame[Parsed]:
+    # One source column cannot satisfy both formats at runtime (the
+    # offset-less format rejects offset suffixes and vice versa) — each
+    # parse reads its own column.
     return df.select(
         ns_naive=pl.col("s").str.to_datetime("%Y-%m-%d %H:%M:%S", time_unit="ns"),
-        us_utc=pl.col("s").str.to_datetime("%Y-%m-%d %H:%M:%S %::z"),
+        us_utc=pl.col("s_off").str.to_datetime("%Y-%m-%d %H:%M:%S %::z"),
     )

--- a/tests/test_runtime_differential.py
+++ b/tests/test_runtime_differential.py
@@ -157,6 +157,18 @@ def _value_overrides() -> dict[str, dict[str, pl.Series]]:
     return {
         # bin.decode("hex") needs even-length hex strings.
         "valid/bin_namespace.py": {"hex_repr": pl.Series(["0a", "1b", "2c"])},
+        # str.to_datetime parses these with explicit formats; generic "s0"
+        # strings raise. The offset column feeds the %::z parse.
+        "valid/str_to_datetime_time_unit.py": {
+            "s": pl.Series(["2020-01-01 00:00:00", "2021-06-15 12:30:00", "2022-12-31 23:59:59"]),
+            "s_off": pl.Series(
+                [
+                    "2020-01-01 00:00:00 +09:00",
+                    "2021-06-15 12:30:00 +00:00",
+                    "2022-12-31 23:59:59 -05:00",
+                ]
+            ),
+        },
         # the fixture exercises the value-dependent Utf8 -> Int64 cast (its own
         # docstring calls it out); generic "s0" strings are not numeric.
         "valid/compare_cast_ok.py": {"s": pl.Series(["1", "2", "3"])},


### PR DESCRIPTION
## What

Adds 11 fixtures (+goldens) pinning seven boundary behaviors that the external adversarial corpus (polypolarism-test `adversarial/`) verified as **correct** during the #63–#92 issue rounds — but which had no fixture in this repo. Per the ADR-0003 rationale, behaviors that were only ever *attacked* (not *fixed*) never got a fixture, so they're free to regress silently; these were the highest-value survivors of ~100 boundary attacks:

| Rule | Valid | Invalid |
| --- | --- | --- |
| absent-tracking edges (#78) | `absent_rename_swap` — the simultaneous swap `{a→b, b→a}` keeps both names (the naive "old names become absent" trap); `absent_reintroduce_join` | `absent_rename_chain` — sequential renames accumulate; `absent_join_no_reintroduce` — a join lacking the name does not resurrect it |
| concat time-unit unification (#66) | `concat_time_unit_same` | `concat_time_unit_mixing` — us vs ns → PLY020 (unit analogue of `tz_mixing`) |
| object-API `strict="filter"` (#88) | `object_api_strict_filter` — extras runtime-valid at input | `object_api_strict_filter_gone` — removed column is a **PLY001 proof** on the closed output |
| `str.to_datetime` `time_unit=` / `%::z` (#66) | `str_to_datetime_time_unit` | `str_to_datetime_time_unit_wrong` |
| bitwise NOT unsigned widths (#72) | `not_bitwise_unsigned_width` — `~UInt8` stays UInt8 | `not_unsigned_declared_i64` |
| bare-return laziness, eager direction (ADR-0006) | (existing `matching_laziness`) | `bare_return_eager_into_lazy` — the direction `adr0006_amendment_proofs` doesn't cover |
| backward narrowing scope (ADR-0006) | `backward_narrowing_scoped` — no cross-variable leak, cleared by rebinding (intentionally unpaired leniency pins; README note added) | — |

## Verification

- Goldens generated with `POLYPOLARISM_UPDATE_EXPECTED=1 uv run pytest tests/test_fixtures.py`; each invalid golden was inspected to fail for the intended column/diagnostic (PLY001-chain message, PLY020, PLY032, PLY040 dtype lines) — no leniency-mediated passes.
- `uv run pytest tests/test_fixtures.py`: 231 passed.
- Runtime behaviors backing the valid sides were demonstrated in the corresponding issue threads (#66 #72 #78 #88 boundary comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)