### PR TITLE
chore: bump POLARS_LATEST_KNOWN to 1.42

### DIFF
--- a/src/polypolarism/version_check.py
+++ b/src/polypolarism/version_check.py
@@ -81,7 +81,7 @@ def _leading_digits(s: str) -> int | None:
 # When polars ships a new minor, bump ``POLARS_LATEST_KNOWN``; only move
 # ``POLARS_FLOOR`` deliberately, with corpus evidence. Anything below the
 # floor triggers a pplw-unsupported-version warning.
-POLARS_LATEST_KNOWN = Version(1, 41, 0)
+POLARS_LATEST_KNOWN = Version(1, 42, 0)
 POLARS_FLOOR = Version(1, 37, 0)
 POLARS_SUPPORT_NOTE = (
     f"polypolarism supports polars >= {POLARS_FLOOR} "


### PR DESCRIPTION
## Summary

Bumps `POLARS_LATEST_KNOWN` in `src/polypolarism/version_check.py` from `Version(1, 41, 0)` to `Version(1, 42, 0)`.

- **polars detected**: 1.42.1, released 2026-06-30 on PyPI
- **POLARS_FLOOR**: remains `Version(1, 37, 0)` — this constant is moved deliberately with corpus evidence (ADR-0004), not automatically when `POLARS_LATEST_KNOWN` advances
- **`pplw-unsupported-version` warning threshold**: unchanged (still fires for polars < 1.37)

Policy reference: [docs/adr/0001-polars-pandera-version-support.md](docs/adr/0001-polars-pandera-version-support.md)

---

## ⚠️ Opened as DRAFT — pre-existing test failures detected

The automated bump routine ran all three verification steps (`pytest -q`, `ruff check`, `ruff format --check`) and found two pre-existing failures **before the bump was applied** (confirmed by reverting the change and re-running the failing test). These failures appear to be a consequence of polars 1.42 being the installed version in the check environment.

### 1. Golden-file mismatch — `tests/fixtures/invalid/patito_struct_missing_field.py`

polars 1.42 changed how integer column types are rendered inside `Struct{...}` descriptions. The golden file contains the 1.41-era string `integer`, but polars 1.42 outputs the canonical `Int64`:

```
- error: [pple-column-not-found] struct.field: 'nope' not found in Struct{name: Utf8, x: integer}
+ error: [pple-column-not-found] struct.field: 'nope' not found in Struct{name: Utf8, x: Int64}
```

**To fix**: verify the new output is correct, then regenerate the golden:
```bash
POLYPOLARISM_UPDATE_EXPECTED=1 uv run pytest tests/test_fixtures.py -k patito_struct_missing_field
# review the diff, then commit the updated .expected file
```

### 2. Ruff format drift — `src/polypolarism/pandera_annotation.py`

`ruff format --check` reports that `src/polypolarism/pandera_annotation.py` would be reformatted (pre-existing, not introduced by this commit).

**To fix**:
```bash
uv run ruff format src/polypolarism/pandera_annotation.py
# review and commit
```

---

Once both pre-existing issues are resolved (either in this PR or separately), remove the draft status and this PR is ready to merge.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WGZhicmMa7di7ysF7XuqCu)_